### PR TITLE
Adds NSBluetoothPeripheralUsageDescription to Info.plist

### DIFF
--- a/ProximityKitReference.xcodeproj/project.pbxproj
+++ b/ProximityKitReference.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 					"$(PROJECT_DIR)/ProximityKitReference",
 				);
 				INFOPLIST_FILE = ProximityKitReference/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.radiusnetworks.ProximityKitReference;
 				PRODUCT_NAME = ProximityKitReference;
@@ -315,6 +316,7 @@
 					"$(PROJECT_DIR)/ProximityKitReference",
 				);
 				INFOPLIST_FILE = ProximityKitReference/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.radiusnetworks.ProximityKitReference;
 				PRODUCT_NAME = ProximityKitReference;

--- a/ProximityKitReference/Info.plist
+++ b/ProximityKitReference/Info.plist
@@ -28,6 +28,8 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+  <key>NSBluetoothPeripheralUsageDescription</key>
+  <string>This app uses Bluetooth to detect beacons.</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
Although it isn't required to actually detect beacons, iTunes Connect
seems to require this key when you're submitting an app.